### PR TITLE
[mu_rprog] Updated instructions for creating a package from scratch (fixes #14)

### DIFF
--- a/mu_rprog/code/RquetteBB/DESCRIPTION
+++ b/mu_rprog/code/RquetteBB/DESCRIPTION
@@ -1,4 +1,5 @@
 Package: RquetteBB
+Type: Package
 Title: Marquette BB in R
 Version: 0.1
 Authors@R: person("James", "Lamb", email = "jaylamb20@gmail.com", role = c("aut", "cre"))
@@ -12,7 +13,10 @@ Imports:
 Suggests:
 	roxygen2,
 	testthat
+URL: https://github.com/jameslamb/teaching/tree/master/mu_rprog/code/RquetteBB
+BugReports: https://github.com/jameslamb/teaching//issues
 License: file LICENSE
 Encoding: UTF-8
 LazyData: true
+VignetteBuilder: knitr
 RoxygenNote: 7.0.2

--- a/mu_rprog/code/Week5_Supplement.Rmd
+++ b/mu_rprog/code/Week5_Supplement.Rmd
@@ -54,42 +54,104 @@ library(testthat)
 
 <h3>Let's get started!</h3>
 
-We can use `devtools` from R to get a headstart! Please do the following:
+You can do most of the setup with R code!
 
-1. set your working directory (with `setwd`) to wherever you'd like the package to live. If you're not sure, just do `setwd("~/repos")`
-2. run `devtools::create('RquetteBB')`
-3. open up `DESCRIPTION` in your text editor of choice
+1. set your working directory (with `setwd()`) to wherever you'd like the package to live.
+
+```{r, eval=FALSE}
+repo_directory <- file.path(Sys.getenv("HOME"), "repos")
+dir.create(
+  repo_directory
+  , showWarnings = FALSE
+)
+setwd(repo_directory)
+```
+
+2. run `package.skeleton()` to create a basic package setup
+
+```{r, eval=FALSE}
+# Create the package skeleton
+package_name <- "RquetteBB"
+package.skeleton(
+  name = package_name
+)
+
+# Remove some unnecessary files
+package_path <- file.path(repo_directory, "RquetteBB")
+file.remove(file.path(package_path, "Read-and-delete-me"))
+file.remove(file.path(package_path, "NAMESPACE"))
+unlink(file.path(package_path, "data"), recursive = TRUE)
+unlink(file.path(package_path, "man"), recursive = TRUE)
+```
+
+3. open up `DESCRIPTION` in the text editor of choice
     - change version number to `0.1`
     - put your information (first name, last name, email) in the `Author` section
     - put an informative description in `Description:`
     - change license to `License: file LICENSE`
     - put an informative Title in `Title:`
-4. delete `RquetteBB.Rpoj`
-5. create a file called `LICENSE`
-    - just write the line: `You can use my stuff but you better give me credit!`
+4. create a file called `LICENSE`
+    - just write the line: ``
+
+```{r, eval=FALSE}
+license_txt <- "You can use my stuff but you better give me credit!"
+license_file <- file.path(package_path, "LICENSE")
+file.create(license_file)
+write(license_txt, file = license_file)
+```
+
+5. create the `man/` directory to store documentation files
+
+```{r, eval=FALSE}
+dir.create(file.path(package_path, "man"), showWarnings = FALSE)
+```
+
 6. create the `tests/` and `tests/testthat` directories
     - create a blank R script, `tests/testthat.R`
     - create a blank R script, `tests/testthat/test-my_functions.R`
+
+```{r, eval=FALSE}
+test_path <- file.path(package_path, "tests", "testthat")
+dir.create(
+    test_path
+    , showWarnings = FALSE
+    , recursive = TRUE
+)
+file.create(file.path(package_path, "tests", "testthat.R"))
+file.create(file.path(test_path, "test-my_functions.R"))
+```
+
 7. create a blank R script, `R/my_functions.R`
 
-I've provided a shell script you can run to generate this package. If you're curious:
+```{r, eval=FALSE}
+file.create(file.path(package_path, "R", "my_functions.R"))
+```
+
+Alternatively, I've provided a shell script you can run to generate this package.
 
 **make_rquettebb_pkg.sh**
 
 ```{r makePackage, engine = 'bash', eval = FALSE, echo = TRUE}
 # Create the package directory
-mkdir -p ~/repos
-cd ~/repos
+mkdir -p ${HOME}/repos
+cd ${HOME}/repos
 
 # Create package skeleton
-Rscript -e "devtools::create('RquetteBB')"
+Rscript -e "package.skeleton(name = 'RquetteBB', list = c('LETTERS'))"
+cd RquetteBB
+
+# Remove unnecessary stuff
+rm Read-and-delete-me
+rm -rf data/
+rm man/*.Rd
+rm NAMESPACE
 
 # Create all the required directories
+mkdir -p R
 mkdir -p tests/testthat
-mkdir man
 
 # Create all the required files
-echo "You can use this but you better cite me!" > LICENSE
+echo 'You can use this but you better cite me!\n' > LICENSE
 touch R/my_functions.R
 touch tests/testthat.R
 touch tests/testthat/test-my_functions.R

--- a/mu_rprog/code/Week5_Supplement.html
+++ b/mu_rprog/code/Week5_Supplement.html
@@ -430,11 +430,33 @@ Building a Package Skeleton
 <h3>
 Let’s get started!
 </h3>
-<p>We can use <code>devtools</code> from R to get a headstart! Please do the following:</p>
+<p>You can do most of the setup with R code!</p>
 <ol style="list-style-type: decimal">
-<li>set your working directory (with <code>setwd</code>) to wherever you’d like the package to live. If you’re not sure, just do <code>setwd(&quot;~/repos&quot;)</code></li>
-<li>run <code>devtools::create('RquetteBB')</code></li>
-<li>open up <code>DESCRIPTION</code> in your text editor of choice
+<li>set your working directory (with <code>setwd()</code>) to wherever you’d like the package to live.</li>
+</ol>
+<pre class="r"><code>repo_directory &lt;- file.path(Sys.getenv(&quot;HOME&quot;), &quot;repos&quot;)
+dir.create(
+  repo_directory
+  , showWarnings = FALSE
+)
+setwd(repo_directory)</code></pre>
+<ol start="2" style="list-style-type: decimal">
+<li>run <code>package.skeleton()</code> to create a basic package setup</li>
+</ol>
+<pre class="r"><code># Create the package skeleton
+package_name &lt;- &quot;RquetteBB&quot;
+package.skeleton(
+  name = package_name
+)
+
+# Remove some unnecessary files
+package_path &lt;- file.path(repo_directory, &quot;RquetteBB&quot;)
+file.remove(file.path(package_path, &quot;Read-and-delete-me&quot;))
+file.remove(file.path(package_path, &quot;NAMESPACE&quot;))
+unlink(file.path(package_path, &quot;data&quot;), recursive = TRUE)
+unlink(file.path(package_path, &quot;man&quot;), recursive = TRUE)</code></pre>
+<ol start="3" style="list-style-type: decimal">
+<li>open up <code>DESCRIPTION</code> in the text editor of choice
 <ul>
 <li>change version number to <code>0.1</code></li>
 <li>put your information (first name, last name, email) in the <code>Author</code> section</li>
@@ -442,33 +464,60 @@ Let’s get started!
 <li>change license to <code>License: file LICENSE</code></li>
 <li>put an informative Title in <code>Title:</code></li>
 </ul></li>
-<li>delete <code>RquetteBB.Rpoj</code></li>
 <li>create a file called <code>LICENSE</code>
 <ul>
-<li>just write the line: <code>You can use my stuff but you better give me credit!</code></li>
+<li>just write the line: ``</li>
 </ul></li>
+</ol>
+<pre class="r"><code>license_txt &lt;- &quot;You can use my stuff but you better give me credit!&quot;
+license_file &lt;- file.path(package_path, &quot;LICENSE&quot;)
+file.create(license_file)
+write(license_txt, file = license_file)</code></pre>
+<ol start="5" style="list-style-type: decimal">
+<li>create the <code>man/</code> directory to store documentation files</li>
+</ol>
+<pre class="r"><code>dir.create(file.path(package_path, &quot;man&quot;), showWarnings = FALSE)</code></pre>
+<ol start="6" style="list-style-type: decimal">
 <li>create the <code>tests/</code> and <code>tests/testthat</code> directories
 <ul>
 <li>create a blank R script, <code>tests/testthat.R</code></li>
 <li>create a blank R script, <code>tests/testthat/test-my_functions.R</code></li>
 </ul></li>
+</ol>
+<pre class="r"><code>test_path &lt;- file.path(package_path, &quot;tests&quot;, &quot;testthat&quot;)
+dir.create(
+    test_path
+    , showWarnings = FALSE
+    , recursive = TRUE
+)
+file.create(file.path(package_path, &quot;tests&quot;, &quot;testthat.R&quot;))
+file.create(file.path(test_path, &quot;test-my_functions.R&quot;))</code></pre>
+<ol start="7" style="list-style-type: decimal">
 <li>create a blank R script, <code>R/my_functions.R</code></li>
 </ol>
-<p>I’ve provided a shell script you can run to generate this package. If you’re curious:</p>
+<pre class="r"><code>file.create(file.path(package_path, &quot;R&quot;, &quot;my_functions.R&quot;))</code></pre>
+<p>Alternatively, I’ve provided a shell script you can run to generate this package.</p>
 <p><strong>make_rquettebb_pkg.sh</strong></p>
 <pre class="bash"><code># Create the package directory
-mkdir -p ~/repos
-cd ~/repos
+mkdir -p ${HOME}/repos
+cd ${HOME}/repos
 
 # Create package skeleton
-Rscript -e &quot;devtools::create('RquetteBB')&quot;
+Rscript -e &quot;package.skeleton(name = 'RquetteBB', list = c('LETTERS'))&quot;
+cd RquetteBB
+
+# Remove unnecessary stuff
+rm Read-and-delete-me
+rm -rf data/
+rm man/*.Rd
+rm NAMESPACE
 
 # Create all the required directories
+mkdir -p R
 mkdir -p tests/testthat
-mkdir man
 
 # Create all the required files
-echo &quot;You can use this but you better cite me!&quot; &gt; LICENSE
+echo 'You can use this but you better cite me!\n' &gt; LICENSE
 touch R/my_functions.R
 touch tests/testthat.R
 touch tests/testthat/test-my_functions.R</code></pre>


### PR DESCRIPTION
Thanks to @amysheep for reporting that `devtools::create()` is deprecated. I decided to drop it from my lecture about creating R packages, and replace it with `package.skeleton()`.

I did look into `usethis::create_package()` and `usethis::use_testthat()`, but `usethis` is too heavy. You have to be able to build some notoriously hard-to-build packages, including `git2r` . and `rlang`, to use it and I don't want to deal with debugging that on each student's unique dev environment.