### PR TITLE
[mu_rprog] lapply

### DIFF
--- a/mu_rprog/code/programming-supplement.Rmd
+++ b/mu_rprog/code/programming-supplement.Rmd
@@ -99,6 +99,7 @@ batting_avg <- c(
   , ortiz = 0.355
   , nixon = 0.285
 )
+print(batting_avg)
 
 # You can combine two vectors with c()
 x <- c("a", "b", "c")
@@ -128,30 +129,6 @@ myList <- list(
 
 # Examine it with str()
 str(myList)
-```
-
-We saw earlier how you can use `for` loops to walk over a vector and do something with each element. You can certainly do the same thing with a list, but it can be a bit tedious.
-
-```{r listLoop}
-# Create a list
-studentList <- list(
-  kanye = c(80, 90, 100)
-  , talib = c(95, 85, 99)
-  , common = c(100, 100, 99)
-)
-
-# Get average grades with a for loop
-grades <- vector(mode = "list", length = 3)
-for (i in 1:length(studentList)){
-    grades[[i]] <- mean(studentList[[i]])
-}
-```
-
-Luckily, R provides a built-in function called `lapply()` to handle this more expressively. We'll cover R's [apply family of functions](https://www.datacamp.com/community/tutorials/r-tutorial-apply-family#gs.ER5hbLU) later in the course. Here's a sneak peek:
-
-```{r listLapply}
-# Better way with lapply
-grades <- lapply(studentList, mean)
 ```
 
 ## Factors
@@ -663,36 +640,21 @@ x
 
 R's `*apply` family of functions are a bit difficult to understand at first, but soon you'll come to love them. They make your code more expressive, flexible, and parallelizable (more on that final point later). One of the most popular is `lapply()` ("list apply"), which loops over a thing (e.g. vector, list) and returns a 1-level list. Let's try it out:
 
-```{r lapplyExample}
-# Get some data
-data("ChickWeight")
-weights <- ChickWeight$weight
-
-# Loop over and encode "above mean" and "below mean"
-the_mean <- mean(weights)
-meanCheck <- function(val, ref_mean){
-    if (val > ref_mean){
-        return("above mean")
-    }
-    if (val < ref_mean){
-        return("below mean")
-    }
-    return("equal to the mean")
-}
-check_vec <- lapply(
-    X = weights
-    , FUN = function(x){
-        meanCheck(val = x, ref_mean = the_mean)
-    }
+```{r listLapply}
+# Create a list
+studentList <- list(
+  kanye = c(80, 90, 100)
+  , talib = c(95, 85, 99)
+  , common = c(100, 100, 99)
 )
 
-# Check it out
-str(check_vec, max.level = 1)
+# Better way with lapply
+grades <- lapply(studentList, mean)
 ```
 
 ## Looping with sapply
 
-On the previous slide, you saw how to loop over a vector/list and get back a list of function results. This may not be appropriate for some settings. Remember that you cannot execute statistical operations like `mean()` over a list. For that, we'd probably prefer to have a *vector* of results. This is where R's `sapply()` ("simplified apply") comes in. `sapply()` works the same way that `lapply()` does but returns a vector. Try it for yourself:
+You've seen how to loop over a vector/list and get back a list of function results. This may not be appropriate for some settings. Remember that you cannot execute statistical operations like `mean()` over a list. For that, we'd probably prefer to have a *vector* of results. This is where R's `sapply()` ("simplified apply") comes in. `sapply()` works the same way that `lapply()` does but returns a vector. Try it for yourself:
 
 ```{r sapplyExample}
 # Get some data


### PR DESCRIPTION
Fixes an issue with `lapply()` being used too early in the course (during the introduction to list objects)