### PR TITLE
[mu_rprog] remove apply() example from intro to data frames

### DIFF
--- a/mu_rprog/code/programming-supplement.Rmd
+++ b/mu_rprog/code/programming-supplement.Rmd
@@ -192,26 +192,6 @@ head(mtcars, n = 10) # could use "tail" for the bottom 10
 unique(mtcars$cyl)
 ```
 
-We will be working with data frames throughout this class, given their importance to data science and statistics. A more thorough treatment of this data structure will be given in Week 2. For now, I'd like to introduce you to one more looping function: `apply()`.
-
-`apply()` allows you to loop over the rows or columns of a data frame and execute an arbitrary function. The code below holds some examples of what can be accomplished with `apply()`.
-
-```{r apply_on_a_DF}
-# Get the mean of each column
-apply(
-  mtcars
-  , MARGIN = 2
-  , FUN = mean
-)
-
-# Get the mean of each row (nonsensical, just illustrating)
-apply(
-  mtcars
-  , MARGIN = 1
-  , FUN = mean
-)
-```
-
 # Logical Operators
 
 Often in your code, you'll want to do/not do something or select / not select some data based on a logical condition (a statement that evaluates to TRUE or FALSE). Here are some examples of how to construct these statements in R.
@@ -678,7 +658,9 @@ check_vec <- sapply(
 
 ## Looping with apply
 
-When analyzing real-world datasets, you may want to use the same looping convention we've been discussing, but apply it over many items and the get some summary (such as the median) of the results. This is where R's `apply()` function comes in! Check it out
+When analyzing real-world datasets, you may want to use the same looping convention we've been discussing, but apply it over many items and the get some summary (such as the median) of the results. This is where R's `apply()` function comes in!
+
+`apply()` allows you to loop over the rows or columns of a data frame and execute an arbitrary function. The code below holds some examples of what can be accomplished with `apply()`.
 
 ```{r applyExample}
 # Get some data

--- a/mu_rprog/slides/Week1_Lecture.Rmd
+++ b/mu_rprog/slides/Week1_Lecture.Rmd
@@ -86,35 +86,35 @@ knit        : slidify::knit2slides
     <li> Vectors <span style="float:right"> 26-27 </span></li>
     <li> Lists <span style="float:right"> 28 </span></li>
     <li> Factors <span style="float:right"> 29 </span></li>
-    <li> Data Frames <span style="float:right"> 30-32 </span></li>
+    <li> Data Frames <span style="float:right"> 30-31 </span></li>
 </ol>
 
 <b class="toc_header"> Logical Operators </b>
 <ol class="toc" type="none">
-    <li> Logical Operators <span style="float:right"> 34-36 </span></li>
+    <li> Logical Operators <span style="float:right"> 33-35 </span></li>
 </ol>
 
 *** =right
 
 <b class="toc_header"> Subsetting </b>
 <ol class="toc" type="none">
-    <li> Subsetting Vectors <span style="float:right"> 38 </span></li>
-    <li> Subsetting Lists <span style="float:right"> 39 </span></li>
-    <li> Subsetting Data Frames <span style="float:right"> 40 </span></li>
-    <li> Using Logical Vectors <span style="float:right"> 41 </span></li>
+    <li> Subsetting Vectors <span style="float:right"> 37 </span></li>
+    <li> Subsetting Lists <span style="float:right"> 38 </span></li>
+    <li> Subsetting Data Frames <span style="float:right"> 39 </span></li>
+    <li> Using Logical Vectors <span style="float:right"> 40 </span></li>
 </ol>
 
 <b class="toc_header"> Controlling Program Flow </b>
 
 <ol class = "toc" type="none">
-    <li> If-Else <span style="float:right"> 42-44 </span></li>
-    <li> For Loops <span style="float:right"> 45 </span></li>
-    <li> While Loops <span style="float:right"> 46 </span></li>
+    <li> If-Else <span style="float:right"> 41-43 </span></li>
+    <li> For Loops <span style="float:right"> 44 </span></li>
+    <li> While Loops <span style="float:right"> 45 </span></li>
 </ol>
 
 <b class="toc_header"> Additional Resources </b>
 <ol class = "toc" type="none">
-    <li> Learning More on Your Own<span style="float:right"> 48 </span></li>
+    <li> Learning More on Your Own<span style="float:right"> 47 </span></li>
 </ol>
 
 --- .section_slide
@@ -608,27 +608,6 @@ head(mtcars, n = 10) # could use "tail" for the bottom 10
 
 # Find all the unique values of "cyl" (the number of engine cylinders)
 unique(mtcars$cyl)
-```
-
---- .content_slide
-
-<footer>
-  <hr>
-  Data Structures<span style="float:right">R Programming</span>
-</footer>
-
-<h2>Data Frames (pt 3)</h2>
-
-We will be working with data frames throughout this class, given their importance to data science and statistics. A more thorough treatment of this data structure will be given in later sections. For now, I'd like to introduce you to one more looping function: `apply()`.
-
-`apply()` allows you to loop over the rows or columns of a data frame and execute an arbitrary function. The code below holds some examples of what can be accomplished with `apply()`.
-
-```{r apply_on_a_DF, eval = FALSE}
-# Get the mean of each column
-apply(mtcars, MARGIN = 2, FUN = mean)
-
-# Get the mean of each row (nonsensical, just illustrating
-apply(mtcars, MARGIN = 1, FUN = mean)
 ```
 
 --- .section_slide

--- a/mu_rprog/slides/Week1_Lecture.html
+++ b/mu_rprog/slides/Week1_Lecture.html
@@ -140,13 +140,13 @@
     <li> Vectors <span style="float:right"> 26-27 </span></li>
     <li> Lists <span style="float:right"> 28 </span></li>
     <li> Factors <span style="float:right"> 29 </span></li>
-    <li> Data Frames <span style="float:right"> 30-32 </span></li>
+    <li> Data Frames <span style="float:right"> 30-31 </span></li>
 </ol>
 
 <p><b class="toc_header"> Logical Operators </b></p>
 
 <ol class="toc" type="none">
-    <li> Logical Operators <span style="float:right"> 34-36 </span></li>
+    <li> Logical Operators <span style="float:right"> 33-35 </span></li>
 </ol>
 
 </div>
@@ -154,24 +154,24 @@
   <p><b class="toc_header"> Subsetting </b></p>
 
 <ol class="toc" type="none">
-    <li> Subsetting Vectors <span style="float:right"> 38 </span></li>
-    <li> Subsetting Lists <span style="float:right"> 39 </span></li>
-    <li> Subsetting Data Frames <span style="float:right"> 40 </span></li>
-    <li> Using Logical Vectors <span style="float:right"> 41 </span></li>
+    <li> Subsetting Vectors <span style="float:right"> 37 </span></li>
+    <li> Subsetting Lists <span style="float:right"> 38 </span></li>
+    <li> Subsetting Data Frames <span style="float:right"> 39 </span></li>
+    <li> Using Logical Vectors <span style="float:right"> 40 </span></li>
 </ol>
 
 <p><b class="toc_header"> Controlling Program Flow </b></p>
 
 <ol class = "toc" type="none">
-    <li> If-Else <span style="float:right"> 42-44 </span></li>
-    <li> For Loops <span style="float:right"> 45 </span></li>
-    <li> While Loops <span style="float:right"> 46 </span></li>
+    <li> If-Else <span style="float:right"> 41-43 </span></li>
+    <li> For Loops <span style="float:right"> 44 </span></li>
+    <li> While Loops <span style="float:right"> 45 </span></li>
 </ol>
 
 <p><b class="toc_header"> Additional Resources </b></p>
 
 <ol class = "toc" type="none">
-    <li> Learning More on Your Own<span style="float:right"> 48 </span></li>
+    <li> Learning More on Your Own<span style="float:right"> 47 </span></li>
 </ol>
 
 </div>
@@ -939,33 +939,7 @@ unique(mtcars$cyl)
   
 </slide>
 
-<slide class="content_slide" id="slide-31" style="background:;">
-  
-  <article data-timings="">
-    <p><footer>
-  <hr>
-  Data Structures<span style="float:right">R Programming</span>
-</footer></p>
-
-<h2>Data Frames (pt 3)</h2>
-
-<p>We will be working with data frames throughout this class, given their importance to data science and statistics. A more thorough treatment of this data structure will be given in later sections. For now, I&#39;d like to introduce you to one more looping function: <code>apply()</code>.</p>
-
-<p><code>apply()</code> allows you to loop over the rows or columns of a data frame and execute an arbitrary function. The code below holds some examples of what can be accomplished with <code>apply()</code>.</p>
-
-<pre><code class="r"># Get the mean of each column
-apply(mtcars, MARGIN = 2, FUN = mean)
-
-# Get the mean of each row (nonsensical, just illustrating
-apply(mtcars, MARGIN = 1, FUN = mean)
-</code></pre>
-
-  </article>
-  <!-- Presenter Notes -->
-  
-</slide>
-
-<slide class="section_slide" id="slide-32" style="background:;">
+<slide class="section_slide" id="slide-31" style="background:;">
   
   <article data-timings="">
     <p></br></br></br></p>
@@ -977,7 +951,7 @@ apply(mtcars, MARGIN = 1, FUN = mean)
   
 </slide>
 
-<slide class="content_slide" id="slide-33" style="background:;">
+<slide class="content_slide" id="slide-32" style="background:;">
   
   <article data-timings="">
     <p><footer>
@@ -1007,7 +981,7 @@ FALSE | FALSE  # FALSE
   
 </slide>
 
-<slide class="content_slide" id="slide-34" style="background:;">
+<slide class="content_slide" id="slide-33" style="background:;">
   
   <article data-timings="">
     <p><footer>
@@ -1041,7 +1015,7 @@ FALSE | FALSE  # FALSE
   
 </slide>
 
-<slide class="content_slide" id="slide-35" style="background:;">
+<slide class="content_slide" id="slide-34" style="background:;">
   
   <article data-timings="">
     <p><footer>
@@ -1070,7 +1044,7 @@ mean(bigCarIndex)
   
 </slide>
 
-<slide class="section_slide" id="slide-36" style="background:;">
+<slide class="section_slide" id="slide-35" style="background:;">
   
   <article data-timings="">
     <p></br></br></br></p>
@@ -1082,7 +1056,7 @@ mean(bigCarIndex)
   
 </slide>
 
-<slide class="content_slide" id="slide-37" style="background:;">
+<slide class="content_slide" id="slide-36" style="background:;">
   
   <article data-timings="">
     <p><footer>
@@ -1112,7 +1086,7 @@ myVec[&quot;var3&quot;]
   
 </slide>
 
-<slide class="content_slide" id="slide-38" style="background:;">
+<slide class="content_slide" id="slide-37" style="background:;">
   
   <article data-timings="">
     <p><footer>
@@ -1131,7 +1105,7 @@ myVec[&quot;var3&quot;]
   
 </slide>
 
-<slide class="content_slide" id="slide-39" style="background:;">
+<slide class="content_slide" id="slide-38" style="background:;">
   
   <article data-timings="">
     <p><footer>
@@ -1163,7 +1137,7 @@ someDF[1:3, c(&quot;wins&quot;, &quot;ppg&quot;)]
   
 </slide>
 
-<slide class="content_slide" id="slide-40" style="background:;">
+<slide class="content_slide" id="slide-39" style="background:;">
   
   <article data-timings="">
     <p><footer>
@@ -1184,7 +1158,7 @@ someDF[1:3, c(&quot;wins&quot;, &quot;ppg&quot;)]
   
 </slide>
 
-<slide class="section_slide" id="slide-41" style="background:;">
+<slide class="section_slide" id="slide-40" style="background:;">
   
   <article data-timings="">
     <p></br></br></br></p>
@@ -1196,7 +1170,7 @@ someDF[1:3, c(&quot;wins&quot;, &quot;ppg&quot;)]
   
 </slide>
 
-<slide class="content_slide" id="slide-42" style="background:;">
+<slide class="content_slide" id="slide-41" style="background:;">
   
   <article data-timings="">
     <p><footer>
@@ -1223,7 +1197,7 @@ if (x &gt; 5){
   
 </slide>
 
-<slide class="content_slide" id="slide-43" style="background:;">
+<slide class="content_slide" id="slide-42" style="background:;">
   
   <article data-timings="">
     <p><footer>
@@ -1252,7 +1226,7 @@ if (4 &gt; 5){
   
 </slide>
 
-<slide class="content_slide" id="slide-44" style="background:;">
+<slide class="content_slide" id="slide-43" style="background:;">
   
   <article data-timings="">
     <p><footer>
@@ -1283,7 +1257,7 @@ for (some_number in x){
   
 </slide>
 
-<slide class="content_slide" id="slide-45" style="background:;">
+<slide class="content_slide" id="slide-44" style="background:;">
   
   <article data-timings="">
     <p><footer>
@@ -1315,7 +1289,7 @@ while (i &lt; 5) {
   
 </slide>
 
-<slide class="section_slide" id="slide-46" style="background:;">
+<slide class="section_slide" id="slide-45" style="background:;">
   
   <article data-timings="">
     <p></br></br></br></p>
@@ -1327,7 +1301,7 @@ while (i &lt; 5) {
   
 </slide>
 
-<slide class="content_slide" id="slide-47" style="background:;">
+<slide class="content_slide" id="slide-46" style="background:;">
   
   <article data-timings="">
     <p><footer>
@@ -1682,13 +1656,6 @@ while (i &lt; 5) {
       <a href="#" target="_self" rel='tooltip' 
         data-slide=46 title='NA'>
          46
-      </a>
-    </li>
-    
-    <li>
-      <a href="#" target="_self" rel='tooltip' 
-        data-slide=47 title='NA'>
-         47
       </a>
     </li>
     


### PR DESCRIPTION
`apply()` is explained later in the course, when `sapply()`, `lapply()`, and `apply()` are introduced together.