### PR TITLE
[mu_rprog] move external packages before debugging

### DIFF
--- a/mu_rprog/code/programming-supplement.Rmd
+++ b/mu_rprog/code/programming-supplement.Rmd
@@ -765,56 +765,6 @@ rwRanges <- apply(
 )
 ```
 
-# Debugging
-
-## Print Debugging
-
-As you've probably already learned, writing code involves a never-ending process of trying this, fixing errors, trying other things, fixing new errors, etc. The process of identifying and fixing errors/bugs is called **debugging**.
-
-The simplest way to debug an issue in your code is to use **print debugging**. This approach involves forming expectations about the state of the objects in your environment at each point in your code, then printing those states at each point to find where things broke.
-
-```{r printDebugging}
-# This function is supposed to sum all the numbers in a vector that are greater than 10
-# but it's breaking with a weird error. Let's use print debugging to dig into it
-sumBigNums <- function(aVector){
-    running_sum <- 0
-    for (num in aVector){
-        if (num >= 10){
-            running_sum <- running_sum + num
-        }
-    }
-    return(running_sum)
-}
-
-# This should return 45...hmmmmmm
-some_vector <- c(11, 20, 5, 9.5, 10, 14)
-sumBigNums(some_vector)
-
-# Let's refactor this function (change the code) and print the status at each stage
-sumBigNums <- function(aVector){
-    running_sum <- 0
-    for (num in aVector){
-        # Grab the sum before we hit this number
-        sum_before <- running_sum
-        
-        # If the number if greater than 10, increase the sum
-        if (num >= 10){
-            running_sum <- running_sum + num
-        }
-        
-        # print new state of the environment
-        msg <- paste0("num: ", num, " | before: ", sum_before, " | after: ", running_sum)
-        print(msg)
-    }
-    return(running_sum)
-}
-
-# Run the code again and look at the output...it looks like we added the number
-# 10 to the count even though it isn't greater than 10! We need to change
-# the code to say "num > 10", not ">="
-sumBigNums(some_vector)
-```
-
 # Using External Packages
 
 This example shows some interesting data visualizations you can make using `{data.table}`, `{quantmod}`, and `{rbokeh}`.
@@ -879,6 +829,56 @@ le_stuff <- sapply(c(1:20), myFunction)
 
 # Plot the result
 plot(x = 1:20, y = le_stuff)
+```
+
+# Debugging
+
+## Print Debugging
+
+As you've probably already learned, writing code involves a never-ending process of trying this, fixing errors, trying other things, fixing new errors, etc. The process of identifying and fixing errors/bugs is called **debugging**.
+
+The simplest way to debug an issue in your code is to use **print debugging**. This approach involves forming expectations about the state of the objects in your environment at each point in your code, then printing those states at each point to find where things broke.
+
+```{r printDebugging}
+# This function is supposed to sum all the numbers in a vector that are greater than 10
+# but it's breaking with a weird error. Let's use print debugging to dig into it
+sumBigNums <- function(aVector){
+    running_sum <- 0
+    for (num in aVector){
+        if (num >= 10){
+            running_sum <- running_sum + num
+        }
+    }
+    return(running_sum)
+}
+
+# This should return 45...hmmmmmm
+some_vector <- c(11, 20, 5, 9.5, 10, 14)
+sumBigNums(some_vector)
+
+# Let's refactor this function (change the code) and print the status at each stage
+sumBigNums <- function(aVector){
+    running_sum <- 0
+    for (num in aVector){
+        # Grab the sum before we hit this number
+        sum_before <- running_sum
+        
+        # If the number if greater than 10, increase the sum
+        if (num >= 10){
+            running_sum <- running_sum + num
+        }
+        
+        # print new state of the environment
+        msg <- paste0("num: ", num, " | before: ", sum_before, " | after: ", running_sum)
+        print(msg)
+    }
+    return(running_sum)
+}
+
+# Run the code again and look at the output...it looks like we added the number
+# 10 to the count even though it isn't greater than 10! We need to change
+# the code to say "num > 10", not ">="
+sumBigNums(some_vector)
 ```
 
 # Working with Files

--- a/mu_rprog/slides/Week2_Lecture.Rmd
+++ b/mu_rprog/slides/Week2_Lecture.Rmd
@@ -55,15 +55,15 @@ widgets     : bootstrap
 
 *** =right
 
-<b class="toc_header"> Debugging Strategies </b>
-<ol class = "toc">
-    <li> Print Debugging <span style="float:right"> 19 </span></li>
-    <li> Googling Around <span style="float:right"> 20-21 </span></li>
-    <li> Stack Overflow <span style="float:right"> 22 </span></li>
-    <li> Building an MWE  <span style="float:right"> 23 </span></li>
-    <li> Built-in Docs with "?" <span style="float:right"> 24 </span></li>
-    <li> Package Vignettes <span style="float:right"> 25 </span></li>
-    <li> Looking at Source Code <span style="float:right"> 26 </span></li>
+<b class="toc_header"> Using External Packages </b>
+<ol class="toc" type="none">
+    <li> Loading Installed Packages <span style="float:right"> 19 </span></li>
+    <li> Installing from CRAN <span style="float:right"> 20 </span></li>
+    <li> Installing from GitHub <span style="float:right"> 21 </span></li>
+    <li> Installing Local Code <span style="float:right"> 22 </span></li>
+    <li> Namespacing Calls <span style="float:right"> 23 </span></li>
+    <li> library() vs. require() <span style="float:right"> 24 </span></li>
+    <li> Using Local Code with source() <span style="float:right"> 25 </span></li>
 </ol>
 
 --- .toc_slide &twocol
@@ -77,15 +77,15 @@ widgets     : bootstrap
 
 *** =left
 
-<b class="toc_header"> Using External Packages </b>
-<ol class="toc" type="none">
-    <li> Loading Installed Packages <span style="float:right"> 28 </span></li>
-    <li> Installing from CRAN <span style="float:right"> 29 </span></li>
-    <li> Installing from GitHub <span style="float:right"> 30 </span></li>
-    <li> Installing Local Code <span style="float:right"> 31 </span></li>
-    <li> Namespacing Calls <span style="float:right"> 32 </span></li>
-    <li> library() vs. require() <span style="float:right"> 33 </span></li>
-    <li> Using Local Code with source() <span style="float:right"> 34 </span></li>
+<b class="toc_header"> Debugging Strategies </b>
+<ol class = "toc">
+    <li> Print Debugging <span style="float:right"> 27 </span></li>
+    <li> Googling Around <span style="float:right"> 28-29 </span></li>
+    <li> Stack Overflow <span style="float:right"> 30 </span></li>
+    <li> Building an MWE  <span style="float:right"> 31 </span></li>
+    <li> Built-in Docs with "?" <span style="float:right"> 32 </span></li>
+    <li> Package Vignettes <span style="float:right"> 33 </span></li>
+    <li> Looking at Source Code <span style="float:right"> 34 </span></li>
 </ol>
 
 *** =right

--- a/mu_rprog/slides/Week2_Lecture.html
+++ b/mu_rprog/slides/Week2_Lecture.html
@@ -102,16 +102,16 @@
 
 </div>
 <div style='float:right;width:48%;'>
-  <p><b class="toc_header"> Debugging Strategies </b></p>
+  <p><b class="toc_header"> Using External Packages </b></p>
 
-<ol class = "toc">
-    <li> Print Debugging <span style="float:right"> 19 </span></li>
-    <li> Googling Around <span style="float:right"> 20-21 </span></li>
-    <li> Stack Overflow <span style="float:right"> 22 </span></li>
-    <li> Building an MWE  <span style="float:right"> 23 </span></li>
-    <li> Built-in Docs with "?" <span style="float:right"> 24 </span></li>
-    <li> Package Vignettes <span style="float:right"> 25 </span></li>
-    <li> Looking at Source Code <span style="float:right"> 26 </span></li>
+<ol class="toc" type="none">
+    <li> Loading Installed Packages <span style="float:right"> 19 </span></li>
+    <li> Installing from CRAN <span style="float:right"> 20 </span></li>
+    <li> Installing from GitHub <span style="float:right"> 21 </span></li>
+    <li> Installing Local Code <span style="float:right"> 22 </span></li>
+    <li> Namespacing Calls <span style="float:right"> 23 </span></li>
+    <li> library() vs. require() <span style="float:right"> 24 </span></li>
+    <li> Using Local Code with source() <span style="float:right"> 25 </span></li>
 </ol>
 
 </div>
@@ -131,16 +131,16 @@
 <h2>Contents</h2>
 
 <div style='float:left;width:48%;' class='centered'>
-  <p><b class="toc_header"> Using External Packages </b></p>
+  <p><b class="toc_header"> Debugging Strategies </b></p>
 
-<ol class="toc" type="none">
-    <li> Loading Installed Packages <span style="float:right"> 28 </span></li>
-    <li> Installing from CRAN <span style="float:right"> 29 </span></li>
-    <li> Installing from GitHub <span style="float:right"> 30 </span></li>
-    <li> Installing Local Code <span style="float:right"> 31 </span></li>
-    <li> Namespacing Calls <span style="float:right"> 32 </span></li>
-    <li> library() vs. require() <span style="float:right"> 33 </span></li>
-    <li> Using Local Code with source() <span style="float:right"> 34 </span></li>
+<ol class = "toc">
+    <li> Print Debugging <span style="float:right"> 27 </span></li>
+    <li> Googling Around <span style="float:right"> 28-29 </span></li>
+    <li> Stack Overflow <span style="float:right"> 30 </span></li>
+    <li> Building an MWE  <span style="float:right"> 31 </span></li>
+    <li> Built-in Docs with "?" <span style="float:right"> 32 </span></li>
+    <li> Package Vignettes <span style="float:right"> 33 </span></li>
+    <li> Looking at Source Code <span style="float:right"> 34 </span></li>
 </ol>
 
 </div>


### PR DESCRIPTION
Some of the debugging strategies involve things like package vignettes on CRAN, so the content on external packages should go before debugging.