### PR TITLE
[mu_rprog] fix dates and grades in final project description

### DIFF
--- a/mu_rprog/assignments/final_project.Rmd
+++ b/mu_rprog/assignments/final_project.Rmd
@@ -75,7 +75,7 @@ This script is the main deliverable for the class...it is worth 20\% of your fin
 
 <h3>Submission</h3>
 
-This component of the project is **due prior to our Week 5 session (Feb 17)**.
+This component of the project is **due prior to our Week 5 session**.
 
 Please submit your code to the "Final Project (script + report)" dropbox on D2L. If you use multiple scripts (totally acceptable!), please include an additional script called "build.R" which species the order to run the scripts in.
 
@@ -150,8 +150,8 @@ Your presentation will be scored out of 100 points, using the following rubric:
 |&nbsp;&nbsp;&nbsp;&nbsp;*(1-4) introduction is confusing or rambling*                  |                          |
 |&nbsp;&nbsp;&nbsp;&nbsp;*(0) no introduction of the problem*                           |                          |
 |&nbsp;&nbsp;2. Explanation of the dataset                                              |30                        |
-|&nbsp;&nbsp;&nbsp;&nbsp;*(30-40) explains source and real-world meaning of the data*   |                          |
-|&nbsp;&nbsp;&nbsp;&nbsp;*(10-29) literal description with no connection to problem*    |                          |
+|&nbsp;&nbsp;&nbsp;&nbsp;*(20-30) explains source and real-world meaning of the data*   |                          |
+|&nbsp;&nbsp;&nbsp;&nbsp;*(10-19) literal description with no connection to problem*    |                          |
 |&nbsp;&nbsp;&nbsp;&nbsp;*(0-9) inaccurate or confusing explanation*                    |                          |
 |&nbsp;&nbsp;3. Explanation of the Code                                                 |40                        |
 |&nbsp;&nbsp;&nbsp;&nbsp;*(30-40) clear explanation of how the code solves the problem* |                          |
@@ -199,8 +199,8 @@ Your report will be scored out of 100 points, using the following rubric:
 |&nbsp;&nbsp;&nbsp;&nbsp;*(1-4) introduction is confusing rambling*                                      |                      |
 |&nbsp;&nbsp;&nbsp;&nbsp;*(0) no introduction of the problem*                                            |                      |
 |&nbsp;&nbsp;2. Explanation of the dataset                                                               |30                    |
-|&nbsp;&nbsp;&nbsp;&nbsp;*(30-40) clear, executive-level explanation*                                    |                      |
-|&nbsp;&nbsp;&nbsp;&nbsp;*(11-29) literal or overly-technical description with no connection to problem* |                      |
+|&nbsp;&nbsp;&nbsp;&nbsp;*(20-30) clear, executive-level explanation*                                    |                      |
+|&nbsp;&nbsp;&nbsp;&nbsp;*(10-19) literal or overly-technical description with no connection to problem* |                      |
 |&nbsp;&nbsp;&nbsp;&nbsp;*(0-9) inaccurate or confusing explanation*                                     |                      |
 |&nbsp;&nbsp;3. Explanation of the result                                                                |25                    |
 |&nbsp;&nbsp;&nbsp;&nbsp;*(20-25) result of the project clearly expressed in business terms*             |                      |

--- a/mu_rprog/assignments/final_project.html
+++ b/mu_rprog/assignments/final_project.html
@@ -482,7 +482,7 @@ Description
 <h3>
 Submission
 </h3>
-<p>This component of the project is <strong>due prior to our Week 5 session (Feb 17)</strong>.</p>
+<p>This component of the project is <strong>due prior to our Week 5 session</strong>.</p>
 <p>Please submit your code to the “Final Project (script + report)” dropbox on D2L. If you use multiple scripts (totally acceptable!), please include an additional script called “build.R” which species the order to run the scripts in.</p>
 <p>Your script will be scored out of 100 points, using the following rubric:</p>
 <table>
@@ -660,11 +660,11 @@ Description and Rubric
 <td align="center">30</td>
 </tr>
 <tr class="even">
-<td align="left">    <em>(30-40) explains source and real-world meaning of the data</em></td>
+<td align="left">    <em>(20-30) explains source and real-world meaning of the data</em></td>
 <td align="center"></td>
 </tr>
 <tr class="odd">
-<td align="left">    <em>(10-29) literal description with no connection to problem</em></td>
+<td align="left">    <em>(10-19) literal description with no connection to problem</em></td>
 <td align="center"></td>
 </tr>
 <tr class="even">
@@ -773,11 +773,11 @@ Submission
 <td align="center">30</td>
 </tr>
 <tr class="even">
-<td align="left">    <em>(30-40) clear, executive-level explanation</em></td>
+<td align="left">    <em>(20-30) clear, executive-level explanation</em></td>
 <td align="center"></td>
 </tr>
 <tr class="odd">
-<td align="left">    <em>(11-29) literal or overly-technical description with no connection to problem</em></td>
+<td align="left">    <em>(10-19) literal or overly-technical description with no connection to problem</em></td>
 <td align="center"></td>
 </tr>
 <tr class="even">

--- a/mu_rprog/code/programming-supplement.Rmd
+++ b/mu_rprog/code/programming-supplement.Rmd
@@ -1463,7 +1463,7 @@ round(cor(swiss), 2)
 
 ## Hypothesis Testing
 
-Though orthodox hypothesis tests have been [maligned in the scientific press recently](http://fivethirtyeight.com/features/statisticians-found-one-thing-they-can-agree-on-its-time-to-stop-misusing-p-values/), they are still enormously valuable tools for discovering differences in datasets and evaluates relationships between variables.
+Hypothesis tests can be enormously valuable tools for discovering differences in datasets and evaluates relationships between variables.
 
 One approach to looking for statistically interesting features (right-hand-side variables) involves binning those variables into "above median" and "below median", and using a paired t-test to see whether or not the variable is statistically related to the target.
 

--- a/mu_rprog/slides/Week4_Lecture.Rmd
+++ b/mu_rprog/slides/Week4_Lecture.Rmd
@@ -145,7 +145,7 @@ str(swiss)
 
 <h2>Hypothesis Testing</h2>
 
-Though orthodox hypothesis tests have been [maligned in the scientific press recently](http://fivethirtyeight.com/features/statisticians-found-one-thing-they-can-agree-on-its-time-to-stop-misusing-p-values/), they are still enormously valuable tools for discovering differences in datasets and evaluates relationships between variables.
+Hypothesis tests can be enormously valuable tools for discovering differences in datasets and evaluates relationships between variables.
 
 One approach to looking for statistically interesting features (right-hand-side variables) involves binning those variables into "above median" and "below median", and using a paired t-test to see whether or not the variable is statistically related to the target.
 

--- a/mu_rprog/slides/Week4_Lecture.html
+++ b/mu_rprog/slides/Week4_Lecture.html
@@ -239,7 +239,7 @@ str(swiss)
 
 <h2>Hypothesis Testing</h2>
 
-<p>Though orthodox hypothesis tests have been <a href="http://fivethirtyeight.com/features/statisticians-found-one-thing-they-can-agree-on-its-time-to-stop-misusing-p-values/">maligned in the scientific press recently</a>, they are still enormously valuable tools for discovering differences in datasets and evaluates relationships between variables.</p>
+<p>Hypothesis tests can be enormously valuable tools for discovering differences in datasets and evaluates relationships between variables.</p>
 
 <p>One approach to looking for statistically interesting features (right-hand-side variables) involves binning those variables into &quot;above median&quot; and &quot;below median&quot;, and using a paired t-test to see whether or not the variable is statistically related to the target.</p>
 


### PR DESCRIPTION
* removes dates from final project - they're unnecessary and easily become inaccurate
* fix some grading-scale issues in the final project rubric (like a 30-point category having a 30-40 range)
* remove old, distracting link to Science article about p-hacking