### PR TITLE
[mu_rprog] remove uses of 'munging' in docs (fixes #137)

### DIFF
--- a/mu_rprog/assignments/final_project.Rmd
+++ b/mu_rprog/assignments/final_project.Rmd
@@ -42,7 +42,7 @@ The ability to use external packages is another key learning outcome for the cou
 For the remainder of this assignment, I'll refer to **the package list**, [this package list I've hosted on GitHub](./final_project_packages.md).
 In this assignment, you must use **at least one** external package from each of the three sections in **the package list**:
 
-* "Data Retrieval and Munging"
+* "Data Retrieval and Transformation"
 * "Math and Statistics"
 * "Visualization, Presentation, and Reporting"
 
@@ -66,7 +66,7 @@ This report should answer the following items:
 - What is the question you're trying to answer?
     - good: *"I am using data on Japanese 10-year bond yields and inflation to predict BOJ monetary policy dovishness / hawkishness."*
     - bad: *"I am analyzing bond data"*
-- What "Data Retrieval and Munging" package do you plan to use? What does that package do?
+- What "Data Retrieval and Transformation" package do you plan to use? What does that package do?
 - What "Math and Statistics" package do you plan to use? What does that package do?
 - What "Visualization, Presentation, and Reporting" package do you plan to use? What does that package do?
 
@@ -101,7 +101,7 @@ Your script will be scored out of 100 points, using the following rubric:
 |:-----------------------------------------------------------------------------------|:------------------------:|
 |**All-or-Nothing Grade Items**                                                      |                          |
 |&nbsp;&nbsp;1. All code runs without error (with no reliance on local data)         |25                        |
-|&nbsp;&nbsp;2. Uses at least one Data Retrieval and Munging package                 |4                         |
+|&nbsp;&nbsp;2. Uses at least one Data Retrieval and Transformation package              |4                         |
 |&nbsp;&nbsp;3. Uses at least one Math and Statistics package                        |4                         |
 |&nbsp;&nbsp;4. Uses at least one Visualization, Presentation, and Reporting package |4                         |
 |&nbsp;&nbsp;5. Every external package used is imported with `library()`             |4                         |

--- a/mu_rprog/assignments/final_project.html
+++ b/mu_rprog/assignments/final_project.html
@@ -446,7 +446,7 @@ package list I’ve hosted on GitHub</a>. In this assignment, you must use
 <strong>at least one</strong> external package from each of the three
 sections in <strong>the package list</strong>:</p>
 <ul>
-<li>“Data Retrieval and Munging”</li>
+<li>“Data Retrieval and Transformation”</li>
 <li>“Math and Statistics”</li>
 <li>“Visualization, Presentation, and Reporting”</li>
 </ul>
@@ -478,8 +478,8 @@ inflation to predict BOJ monetary policy dovishness /
 hawkishness.”</em></li>
 <li>bad: <em>“I am analyzing bond data”</em></li>
 </ul></li>
-<li>What “Data Retrieval and Munging” package do you plan to use? What
-does that package do?</li>
+<li>What “Data Retrieval and Transformation” package do you plan to use?
+What does that package do?</li>
 <li>What “Math and Statistics” package do you plan to use? What does
 that package do?</li>
 <li>What “Visualization, Presentation, and Reporting” package do you
@@ -540,8 +540,8 @@ local data)</td>
 <td align="center">25</td>
 </tr>
 <tr class="odd">
-<td align="left">  2. Uses at least one Data Retrieval and Munging
-package</td>
+<td align="left">  2. Uses at least one Data Retrieval and
+Transformation package</td>
 <td align="center">4</td>
 </tr>
 <tr class="even">

--- a/mu_rprog/assignments/final_project_packages.md
+++ b/mu_rprog/assignments/final_project_packages.md
@@ -1,6 +1,6 @@
 ## External Packages for Final Project
 
-**Data Retrieval and Munging**
+**Data Retrieval and Transformation**
 
 - arrow
 - ctar

--- a/mu_rprog/assignments/programming_assignment2.Rmd
+++ b/mu_rprog/assignments/programming_assignment2.Rmd
@@ -24,7 +24,7 @@ In this part of the assignment, I'd like you to practice reading and running the
 - `str_extract()` from the `{stringr}` package
 - `setnames()` from the `{data.table}` package
 - `map_dbl()` from the `{purrr}` package
-- Two functions from the "Data Retrieval and Munging" section of **the package list**
+- Two functions from the "Data Retrieval and Transformation" section of **the package list**
     - NOTE: must be from two different packages
 - Two functions from the "Math and Statistics" section of **the package list**
     - NOTE: must be from two different packages

--- a/mu_rprog/assignments/programming_assignment2.html
+++ b/mu_rprog/assignments/programming_assignment2.html
@@ -411,8 +411,8 @@ package</li>
 <li><code>setnames()</code> from the <code>{data.table}</code>
 package</li>
 <li><code>map_dbl()</code> from the <code>{purrr}</code> package</li>
-<li>Two functions from the “Data Retrieval and Munging” section of
-<strong>the package list</strong>
+<li>Two functions from the “Data Retrieval and Transformation” section
+of <strong>the package list</strong>
 <ul>
 <li>NOTE: must be from two different packages</li>
 </ul></li>

--- a/mu_rprog/slides/Week3_Lecture.Rmd
+++ b/mu_rprog/slides/Week3_Lecture.Rmd
@@ -394,7 +394,7 @@ What if you have 5 tables? 10? 1000? Use `data.table::rbindlist()`.
 
 **Choosing External Packages**
 
-- You need to choose one data munging package, one statistics package, and one visualization package from [this list](../assignments/final_project_packages.md)
+- You need to choose one data retrieval package, one statistics package, and one visualization package from [this list](../assignments/final_project_packages.md)
 - Don't stress! You can do all of the following:
     - Change which packages you actually use in the final project
     - Use a package that isn't on the list (as long as you clear it with me)

--- a/mu_rprog/slides/Week3_Lecture.html
+++ b/mu_rprog/slides/Week3_Lecture.html
@@ -600,7 +600,7 @@ cleanDF &lt;- randomForest::na.roughfix(testDF)
 <p><strong>Choosing External Packages</strong></p>
 
 <ul>
-<li>You need to choose one data munging package, one statistics package, and one visualization package from <a href="../assignments/final_project_packages.md">this list</a></li>
+<li>You need to choose one data retrieval package, one statistics package, and one visualization package from <a href="../assignments/final_project_packages.md">this list</a></li>
 <li>Don&#39;t stress! You can do all of the following:
 
 <ul>


### PR DESCRIPTION
Fixes #137.

Replaces uses of the word "munging" in the course docs with "transformation". I think that's more likely to be understood by a general audience.