### PR TITLE
[mu_rprog] factor out 'rbokeh'

### DIFF
--- a/mu_rprog/assignments/final_project_packages.md
+++ b/mu_rprog/assignments/final_project_packages.md
@@ -59,6 +59,5 @@
 - openxlsx
 - patchwork
 - plotly
-- rbokeh
 - RColorBrewer
 - stargazer

--- a/mu_rprog/code/programming-supplement.Rmd
+++ b/mu_rprog/code/programming-supplement.Rmd
@@ -788,7 +788,7 @@ quantmod::getSymbols(
     , auto.assign = TRUE
 )
 cpiDT <- data.table::data.table(
-    CPIAUCSL
+    CPIAUCSL["1947-01-01/2023-11-01"]
     , keep.rownames = TRUE
 )
 

--- a/mu_rprog/code/programming-supplement.Rmd
+++ b/mu_rprog/code/programming-supplement.Rmd
@@ -767,38 +767,36 @@ rwRanges <- apply(
 
 # Using External Packages
 
-This example shows some interesting data visualizations you can make using `{data.table}`, `{quantmod}`, and `{rbokeh}`.
+This example shows some interesting data visualizations you can make using `{data.table}`, `{dygraphs}`, and `{quantmod}`.
 
 Install these packages:
 
 ```r
-install.packages(c("data.table", "quantmod", "rbokeh"))
+install.packages(c("data.table", "dygraphs", "quantmod"))
 ```
 
 ```{r makePlots, echo = TRUE, eval = TRUE, message = FALSE, warning = FALSE}
 # Load dependencies
 library(data.table)
+library(dygraphs)
 library(quantmod)
-library(rbokeh)
 
-# Get data and plot it
-quantmod::getSymbols(
+# Get data
+cpiData <- quantmod::getSymbols(
     Symbols = "CPIAUCSL"
     , src = "FRED"
-    , auto.assign = TRUE
-)
-cpiDT <- data.table::data.table(
-    CPIAUCSL["1947-01-01/2023-11-01"]
-    , keep.rownames = TRUE
-)
+    , auto.assign = FALSE
+)["1947-01-01/2023-11-01"]
 
 # Plot it!
-rbokeh::figure(
-    data = cpiDT
-    , title = "U.S. CPI"
-    , ylab = "Index (1982-1984 = 100)"
+dygraphs::dygraph(
+    data = cpiData
+    , main = "U.S. CPI"
     , xlab = "date"
-) %>% ly_lines(x = cpiDT$index, y = cpiDT$CPIAUCSL, color = "blue")
+    , ylab = "Index (1982-1984 = 100)"
+    , elementId = "plot"
+) %>%
+    dygraphs::dyRangeSelector()
 ```
 
 ## Sourcing Helper Functions
@@ -2157,12 +2155,10 @@ My script below shows an example of a typical layout for professional-quality R 
 #===== 1. Setup =====#
 
 # Load dependencies
-library(data.table)
+library(dygraphs)
 library(quantmod)
-library(rbokeh)
-library(purrr)
 
-# Set global params
+# Set script-level constants
 FRED_SERIES <- "CPIAUCSL" # UNRATE
 TITLE       <- "U.S. CPI" # "U.S. unemployment""
 VAR_UNITS   <- "Index (1982-1984 = 100)" # "% of labor force"
@@ -2170,32 +2166,23 @@ VAR_UNITS   <- "Index (1982-1984 = 100)" # "% of labor force"
 #===== 2. Get Data =====#
 
 # Get data from FRED
-quantmod::getSymbols(
+cpiData <- quantmod::getSymbols(
     Symbols = FRED_SERIES
     , src = "FRED"
-    , auto.assign = TRUE
-)
-
-# Put it in a data.table
-dataDT <- data.table::data.table(
-    get(FRED_SERIES)
-    , keep.rownames = TRUE
+    , auto.assign = FALSE
 )
 
 #===== 3. Plot it! =====#
 
 # Plot it!
-rbokeh::figure(
-    data = dataDT
-    , title = TITLE
-    , ylab = VAR_UNITS
+dygraphs::dygraph(
+    data = cpiData
+    , main = TITLE
     , xlab = "date"
-    , width = 800
-) %>% rbokeh::ly_lines(
-    x = dataDT[,index]
-    , y = dataDT[,get(FRED_SERIES)]
-    , color = "blue"
-  )
+    , ylab = VAR_UNITS
+    , elementId = "plot"
+) %>%
+    dygraphs::dyRangeSelector()
 ```
 
 # Creating R Packages

--- a/mu_rprog/install-deps.R
+++ b/mu_rprog/install-deps.R
@@ -10,14 +10,14 @@ if (!requireNamespace("slidifyLibraries")) {
 
 install.packages(
     pkgs = c(
-        "ineq"
+        "dygraphs"
+        , "ineq"
         , "jsonlite"
         , "lubridate"
         , "openxlsx"
         , "quantmod"
         , "randomForest"
         , "rattle"
-        , "rbokeh"
         , "remotes"
         , "stringr"
     )

--- a/mu_rprog/slides/Week2_Lecture.Rmd
+++ b/mu_rprog/slides/Week2_Lecture.Rmd
@@ -506,20 +506,22 @@ https://github.com/microsoft/LightGBM
 
 <h2>Loading Installed Packages</h2>
 
-As you advance in R, you will find that the functions provided by packages like `{base}`, `{stats}`, and `{utils}` are not sufficient. For example, you may want to use `{rbokeh}` to make interactive plots.
+As you advance in R, you will find that the functions provided by packages like `{base}`, `{stats}`, and `{utils}` are not sufficient. For example, you may want to use `{dygraphs}` to make interactive plots.
 
 ```{r makePlots, echo = TRUE, eval = FALSE, message = FALSE, warning = FALSE}
 # Load dependencies
-library(data.table); library(quantmod); library(rbokeh);
+library(data.table); library(dygraphs); library(quantmod);
 
-# Get data and plot it
-quantmod::getSymbols('CPIAUCSL', src = 'FRED', auto.assign = TRUE)
-cpiDT <- data.table::data.table(CPIAUCSL, keep.rownames = TRUE)
+# Get data
+cpiData <- quantmod::getSymbols(
+    Symbols = "CPIAUCSL", src = "FRED", auto.assign = FALSE
+)["1947-01-01/2023-11-01"]
 
-# Plot it!
-rbokeh::figure(data = cpiDT, title = "U.S. CPI",
-               ylab = "Index (1982-1984 = 100)", xlab = "date") %>%
-        ly_lines(x = cpiDT$index, y = cpiDT$CPIAUCSL, color = "blue")
+# Plot it
+dygraphs::dygraph(
+    data = cpiData, main = "U.S. CPI", xlab = "date", ylab = "Index (1982-1984 = 100)", elementId = "plot"
+) %>%
+    dygraphs::dyRangeSelector()
 ```
 
 --- .content_slide

--- a/mu_rprog/slides/Week2_Lecture.html
+++ b/mu_rprog/slides/Week2_Lecture.html
@@ -717,19 +717,21 @@ apply(ChickWeight, MARGIN = 1, FUN = function(blah){range(as.numeric(blah))})
 
 <h2>Loading Installed Packages</h2>
 
-<p>As you advance in R, you will find that the functions provided by packages like <code>{base}</code>, <code>{stats}</code>, and <code>{utils}</code> are not sufficient. For example, you may want to use <code>{rbokeh}</code> to make interactive plots.</p>
+<p>As you advance in R, you will find that the functions provided by packages like <code>{base}</code>, <code>{stats}</code>, and <code>{utils}</code> are not sufficient. For example, you may want to use <code>{dygraphs}</code> to make interactive plots.</p>
 
 <pre><code class="r"># Load dependencies
-library(data.table); library(quantmod); library(rbokeh);
+library(data.table); library(dygraphs); library(quantmod);
 
-# Get data and plot it
-quantmod::getSymbols(&#39;CPIAUCSL&#39;, src = &#39;FRED&#39;, auto.assign = TRUE)
-cpiDT &lt;- data.table::data.table(CPIAUCSL, keep.rownames = TRUE)
+# Get data
+cpiData &lt;- quantmod::getSymbols(
+    Symbols = &quot;CPIAUCSL&quot;, src = &quot;FRED&quot;, auto.assign = FALSE
+)[&quot;1947-01-01/2023-11-01&quot;]
 
-# Plot it!
-rbokeh::figure(data = cpiDT, title = &quot;U.S. CPI&quot;,
-               ylab = &quot;Index (1982-1984 = 100)&quot;, xlab = &quot;date&quot;) %&gt;%
-        ly_lines(x = cpiDT$index, y = cpiDT$CPIAUCSL, color = &quot;blue&quot;)
+# Plot it
+dygraphs::dygraph(
+    data = cpiData, main = &quot;U.S. CPI&quot;, xlab = &quot;date&quot;, ylab = &quot;Index (1982-1984 = 100)&quot;, elementId = &quot;plot&quot;
+) %&gt;%
+    dygraphs::dyRangeSelector()
 </code></pre>
 
   </article>

--- a/mu_rprog/slides/Week3_Lecture.Rmd
+++ b/mu_rprog/slides/Week3_Lecture.Rmd
@@ -299,10 +299,10 @@ You can combine multiple plots in a grid layout. See ["The Base Plotting System"
 
 We don't have time in this short class to go into great depth on data visualization, but I want you to know that there are a bunch of cool visualization libraries a short `install.packages()` away!
 
+- [dygraphs](https://rstudio.github.io/dygraphs/): high-level library for creating interactive charts that can be embedded directly in HTML
 - [ggplot2](http://www.r-graph-gallery.com/portfolio/ggplot2-package/): One of the most popular packages in the R world. Based on the "grammar of graphics" approach to building plots
 - [googleVis](https://cran.r-project.org/web/packages/googleVis/vignettes/googleVis_examples.html): Send your data to the google charts API to make fancy interactive visualizations
 - [plotly](https://plotly.com/r/): easy-to-use library for creating interactive data visualizations and dashboards
-- [rbokeh](https://hafen.github.io/rbokeh/#preview): high-level library for creating interactive charts that can be embedded directly in HTML
 
 --- .content_slide
 

--- a/mu_rprog/slides/Week3_Lecture.html
+++ b/mu_rprog/slides/Week3_Lecture.html
@@ -453,10 +453,10 @@ cleanDF &lt;- randomForest::na.roughfix(testDF)
 <p>We don&#39;t have time in this short class to go into great depth on data visualization, but I want you to know that there are a bunch of cool visualization libraries a short <code>install.packages()</code> away!</p>
 
 <ul>
+<li><a href="https://rstudio.github.io/dygraphs/">dygraphs</a>: high-level library for creating interactive charts that can be embedded directly in HTML</li>
 <li><a href="http://www.r-graph-gallery.com/portfolio/ggplot2-package/">ggplot2</a>: One of the most popular packages in the R world. Based on the &quot;grammar of graphics&quot; approach to building plots</li>
 <li><a href="https://cran.r-project.org/web/packages/googleVis/vignettes/googleVis_examples.html">googleVis</a>: Send your data to the google charts API to make fancy interactive visualizations</li>
 <li><a href="https://plotly.com/r/">plotly</a>: easy-to-use library for creating interactive data visualizations and dashboards</li>
-<li><a href="https://hafen.github.io/rbokeh/#preview">rbokeh</a>: high-level library for creating interactive charts that can be embedded directly in HTML</li>
 </ul>
 
   </article>


### PR DESCRIPTION
`{rbokeh}` is now abandoned: https://github.com/bokeh/rbokeh/commit/2c92dd69f6f69dd61b3fd3cbee142c35415ad848

In addition, some of the `{rbokeh}` examples in the R class's materials caused unnecessary churn in git diffs.

This fixes both of those problems:

* removes all `{rbokeh}` references in the course docs
* replaces code samples using `{rbokeh}` with `{dygraphs}`
* limits pulls of real CPI data from FRED to an explicit date range (so the exact same data will be pulled when these docs are re-generated 6  months from now)