### PR TITLE
[mu_rprog] clarify final project language in syllabus

### DIFF
--- a/mu_rprog/assignments/final_project.Rmd
+++ b/mu_rprog/assignments/final_project.Rmd
@@ -132,22 +132,30 @@ For some tips, see [this code-commenting tutorial](https://www.learncpp.com/cpp-
 
 <h2>Part 3: Code Review</h2>
 
-In professional data science teams, it is common for team members to present their work in internal "code reviews", small meetings where a data scientist shares brief background on the problem he/she sought to solve and then invites criticism of his/her code.
+In professional data science teams, it is common for team members to present their work in internal "code reviews",
+small meetings where a data scientist shares brief background on the problem he/she sought to solve and then
+invites criticism of his/her code.
 
-This can be a nerve-wracking experience in the context of a new job (trust me), so I'd like to give you the opportunity to practice sharing code with others in the safe setting of this introductory course.
+This can be a nerve-wracking experience in the context of a new job (trust me), so I'd like to give you the opportunity
+to practice sharing code with others in the safe setting of this introductory course.
 In the code review component of this project, you will do a 5-10 minutes live presentation of your final project.
 
 <h3>Submission (in-person class)</h3>
 
 Code reviews will be done in-class **during the Week 5 session**.
+
 You do not need to present slides or turn in anything on D2L.
-Please set up a Google doc called "FIRSTNAME LASTNAME <> MU RPROG Code Review" with permissions "anyone with the link can edit".
+
+When presentations begin, a Google Doc will be shared with the class.
+
 While you present, everyone in the class will have this doc up on their machines and use it to give you comments and questions.
-The benefit of this practice, in professional settings, is that days after your code review you'll have a written record of your audience's feedback.
+The benefit of this practice, in professional settings, is that days after your code review you'll have a written record of
+your audience's feedback.
 
 <h3>Description and Rubric</h3>
 
 Be prepared to show your code + report in front of the class.
+
 Your code review should consist of the following:
 
 - Introduce the problem you investigated.
@@ -176,7 +184,7 @@ Your presentation will be scored out of 100 points, using the following rubric:
 |&nbsp;&nbsp;&nbsp;&nbsp;*(10-29) literal description of the code as-is*                |                          |
 |&nbsp;&nbsp;&nbsp;&nbsp;*(0-9) inaccurate or confusing explanation*                    |                          |
 
-Avoid these common code review pitfalls:
+Avoid these common code review issues:
 
 * introducing the problem by just describing what you did
   * bad: *"I used data from FRED with R"*

--- a/mu_rprog/assignments/final_project.html
+++ b/mu_rprog/assignments/final_project.html
@@ -669,18 +669,20 @@ presentation of your final project.</p>
 Submission (in-person class)
 </h3>
 <p>Code reviews will be done in-class <strong>during the Week 5
-session</strong>. You do not need to present slides or turn in anything
-on D2L. Please set up a Google doc called “FIRSTNAME LASTNAME &lt;&gt;
-MU RPROG Code Review” with permissions “anyone with the link can edit”.
-While you present, everyone in the class will have this doc up on their
-machines and use it to give you comments and questions. The benefit of
-this practice, in professional settings, is that days after your code
-review you’ll have a written record of your audience’s feedback.</p>
+session</strong>.</p>
+<p>You do not need to present slides or turn in anything on D2L.</p>
+<p>When presentations begin, a Google Doc will be shared with the
+class.</p>
+<p>While you present, everyone in the class will have this doc up on
+their machines and use it to give you comments and questions. The
+benefit of this practice, in professional settings, is that days after
+your code review you’ll have a written record of your audience’s
+feedback.</p>
 <h3>
 Description and Rubric
 </h3>
-<p>Be prepared to show your code + report in front of the class. Your
-code review should consist of the following:</p>
+<p>Be prepared to show your code + report in front of the class.</p>
+<p>Your code review should consist of the following:</p>
 <ul>
 <li>Introduce the problem you investigated.</li>
 <li>Explain the data set <em>(where did it come from? what variables
@@ -778,7 +780,7 @@ explanation</em></td>
 </tr>
 </tbody>
 </table>
-<p>Avoid these common code review pitfalls:</p>
+<p>Avoid these common code review issues:</p>
 <ul>
 <li>introducing the problem by just describing what you did
 <ul>

--- a/mu_rprog/assignments/programming_assignment1.html
+++ b/mu_rprog/assignments/programming_assignment1.html
@@ -1552,8 +1552,10 @@ D2L.</li>
 #
 #    Your code in print() must reference the variable my_name.
 #
-#    Only modify code between the &#39;### BEGIN ###&#39; and &#39;### END ###&#39;.
+#    Only modify code between &#39;### BEGIN ###&#39; and &#39;### END ###&#39; comments.
+### BEGIN ###
 my_name &lt;- &quot;James&quot;
+### END ####
 print(
     ### BEGIN ###
     &quot;hello,&quot;, myname, &quot;    is &quot;, James

--- a/mu_rprog/syllabus.Rmd
+++ b/mu_rprog/syllabus.Rmd
@@ -239,11 +239,11 @@ The project comprises the following parts:
 Full details of the project and each of its components are available at [https://jameslamb.github.io/teaching/mu_rprog/assignments/final_project.html](https://jameslamb.github.io/teaching/mu_rprog/assignments/final_project.html).
 All times below are in Central Time.
 
-|Assignment                      |Due                          |
-|:------------------------------:|:---------------------------:|
-|Final Project proposal          | 11:00p on February 10, 2024 |
-|Final Project (script + report) | 11:00p on February 17, 2024 |
-|Final Project code review video | 11:00p on February 17, 2024 |
+|Assignment                             |Due                            |
+|:-------------------------------------:|:-----------------------------:|
+|Final Project proposal                 | 11:00p on February 10, 2024   |
+|Final Project (script + report)        | 11:00p on February 17, 2024   |
+|Final Project code review presentation | live, 9:00a February 17, 2024 |
 
 ## D. Extra Credit
 

--- a/mu_rprog/syllabus.html
+++ b/mu_rprog/syllabus.html
@@ -1872,6 +1872,10 @@ project, presented live in the final week of the course.</li>
 at <a href="https://jameslamb.github.io/teaching/mu_rprog/assignments/final_project.html">https://jameslamb.github.io/teaching/mu_rprog/assignments/final_project.html</a>.
 All times below are in Central Time.</p>
 <table>
+<colgroup>
+<col width="55%" />
+<col width="44%" />
+</colgroup>
 <thead>
 <tr class="header">
 <th align="center">Assignment</th>
@@ -1888,8 +1892,8 @@ All times below are in Central Time.</p>
 <td align="center">11:00p on February 17, 2024</td>
 </tr>
 <tr class="odd">
-<td align="center">Final Project code review video</td>
-<td align="center">11:00p on February 17, 2024</td>
+<td align="center">Final Project code review presentation</td>
+<td align="center">live, 9:00a February 17, 2024</td>
 </tr>
 </tbody>
 </table>


### PR DESCRIPTION
Clarifies that the final project code review is a live presentation, not a recorded video.