### PR TITLE
[ci] set up dependabot, update pre-commit hooks

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -7,6 +7,6 @@ CRAN_MIRROR="https://cloud.r-project.org/"
 
 if [[ $TASK == "lint-r" ]]; then
     Rscript --vanilla -e "install.packages('lintr', repos = '${CRAN_MIRROR}', dependencies = c('Depends', 'Imports', 'LinkingTo'))"
-    Rscript .ci/lint-r-code.R $(pwd)/mu_rprog
+    Rscript .ci/lint-r-code.R ./mu_rprog
     exit 0
 fi

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+---
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      ci-dependencies:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "[ci]"
+    labels:
+      - maintenance

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: false
+          miniforge-version: latest
       - name: set up R
         uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,10 +3,10 @@ name: GitHub Actions
 on:
   push:
     branches:
-    - main
+      - main
   pull_request:
     branches:
-    - main
+      - main
 
 jobs:
   test:
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-    - name: Note that all tests succeeded
-      uses: re-actors/alls-green@v1.2.2
-      with:
-        jobs: ${{ toJSON(needs) }}
+      - name: Note that all tests succeeded
+        uses: re-actors/alls-green@v1.2.2
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,21 @@ exclude: |
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
+  - repo: https://github.com/maxwinterstein/shfmt-py
+    rev: v3.7.0.1
+    hooks:
+      - id: shfmt
+        args: ["--indent=4", "--space-redirects", "--write"]
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
+    hooks:
+      - id: shellcheck
+        args: ["--exclude=SC2002"]
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.35.1
+    hooks:
+      - id: yamllint

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,23 @@
+extends: default
+
+rules:
+  anchors:
+    forbid-undeclared-aliases: true
+    forbid-duplicated-anchors: true
+    forbid-unused-anchors: true
+  braces:
+    forbid: false
+    min-spaces-inside: 0
+    # allow 1 space for jinja templating in conda recipes
+    max-spaces-inside: 1
+    min-spaces-inside-empty: -1
+    max-spaces-inside-empty: -1
+  document-start: disable
+  line-length:
+    max: 120
+  truthy:
+    allowed-values: ['false', 'true']
+    # having problematic value in keys is rare... and also
+    # GitHub Actions' choie of 'on:' triggers this check
+    # ref: https://github.com/adrienverge/yamllint/issues/430
+    check-keys: false

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,0 @@
-.PHONY: lint
-lint:
-	Rscript ./.ci/lint-r-code.R $${PWD}/mu_rprog


### PR DESCRIPTION
Some misc. cleanup ahead of the next round of edits for the R course.

* updates `pre-commit` hooks
* adds `shfmt`, `shellcheck`, and `yamllint` to `pre-commit` hooks + fixes issues they found
* removes root-level `Makefile` (unused)
* adds dependabot configuration, so dependabot will automatically suggest updating GitHub Actions ([docs link](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot))
* switches from miniconda to miniforge for CI environment