### PR TITLE
update lecture video links, add notes on course site changes

### DIFF
--- a/assignments/final_project.Rmd
+++ b/assignments/final_project.Rmd
@@ -46,7 +46,7 @@ In this assignment, you must use **at least one** external package from each of 
 * "Math and Statistics"
 * "Visualization, Presentation, and Reporting"
 
-**NOTE: "external" means that packages that do not come pre-installed with R. The following can be used, but don't count towards this requirement: `{base}`, `{datasets}`, `{graphics}`, `{grDevices}`, `{methods}`, `{stats}`, and `{utils}`.
+**NOTE:** "external" means that packages that do not come pre-installed with R. The following can be used, but don't count towards this requirement: `{base}`, `{datasets}`, `{graphics}`, `{grDevices}`, `{methods}`, `{stats}`, and `{utils}`.
 
 You are, of course, welcome to use any other packages you deem appropriate *in addition to this minimum requirement*.
 

--- a/assignments/final_project.html
+++ b/assignments/final_project.html
@@ -449,9 +449,9 @@ sections in <strong>the package list</strong>:</p>
 <li>“Math and Statistics”</li>
 <li>“Visualization, Presentation, and Reporting”</li>
 </ul>
-<p>**NOTE: “external” means that packages that do not come pre-installed
-with R. The following can be used, but don’t count towards this
-requirement: <code>{base}</code>, <code>{datasets}</code>,
+<p><strong>NOTE:</strong> “external” means that packages that do not
+come pre-installed with R. The following can be used, but don’t count
+towards this requirement: <code>{base}</code>, <code>{datasets}</code>,
 <code>{graphics}</code>, <code>{grDevices}</code>,
 <code>{methods}</code>, <code>{stats}</code>, and
 <code>{utils}</code>.</p>

--- a/assignments/programming_assignment1.Rmd
+++ b/assignments/programming_assignment1.Rmd
@@ -57,7 +57,7 @@ print(
     ### END ####
 )
 
-# b. Write a function that takes in a positive integer `n`` and returns a character vector with
+# b. Write a function that takes in a positive integer `n` and returns a character vector with
 #    the nth element repeated n times. e.g.:
 #
 #    RepLetter(1) should yield c("a")

--- a/assignments/programming_assignment1.html
+++ b/assignments/programming_assignment1.html
@@ -1558,7 +1558,7 @@ print(
     ### END ####
 )
 
-# b. Write a function that takes in a positive integer `n`` and returns a character vector with
+# b. Write a function that takes in a positive integer `n` and returns a character vector with
 #    the nth element repeated n times. e.g.:
 #
 #    RepLetter(1) should yield c(&quot;a&quot;)

--- a/syllabus.Rmd
+++ b/syllabus.Rmd
@@ -66,6 +66,12 @@ All lectures are delivered asynchronously, via those pre-recorded videos.
 
 Videos describing the solutions to quizzes and assignments will be made available after the deadlines for those items.
 
+#### A note on the course site
+
+The course site moved to https://jameslamb.github.io/intro-to-r in late 2025.
+
+If you find any broken links anywhere, please inform the instructor.
+
 ### Required Hardware
 
 \textcolor{red}{You are required to use your own computer for this class.}
@@ -88,17 +94,18 @@ As long as you meet all deadlines in the course, you can approach the material a
 Recommended sequence:
 
 1. Read this syllabus
-2. Accept the calendar invitation for the final project presentation call.
-3. bookmark the course resources:
-    * course site ([link](https://jameslamb.github.io/intro-to-r/))
+2. Watch the syllabus review video ([link](https://drive.google.com/file/d/1DeNScj4ZgUrFV6R5BNTvKe-KVTfa8M3a/view?usp=drive_link))
+3. Accept the calendar invitation for the final project presentation call.
+4. bookmark the course resources:
+    * course site (https://jameslamb.github.io/intro-to-r/)
     * programming supplement: ([link](https://jameslamb.github.io/intro-to-r/code/programming-supplement.html))
     * office hours link: https://calendar.app.google/iKAUGVQjBhegyLHH8
-4. Watch the course intro video ([link](https://drive.google.com/file/d/1BHRiFxOTSNRXyD1rAF7CPa7MC3xD3sRf/view?usp=drive_link))
-5. **(due January 17, 2026)** Take the `pre-course survey` on D2L
-6. Set up your development environment
+5. Watch the course intro video ([link](https://drive.google.com/file/d/1BHRiFxOTSNRXyD1rAF7CPa7MC3xD3sRf/view?usp=drive_link))
+6. **(due January 17, 2026)** Take the `pre-course survey` on D2L
+7. Set up your development environment
     * install R on your personal computer (https://cloud.r-project.org/)
     * install RStudio (the free one!!!) on your personal computer (https://posit.co/products/open-source/rstudio/)
-7. Review Week 1 lecture materials
+8. Review Week 1 lecture materials
     * lecture videos ([link](https://drive.google.com/drive/folders/1wR0qZgDKSiOnhwlEkWiMjvhavuGi4WK2))
     * Programming Supplement topics ([link](https://jameslamb.github.io/intro-to-r/code/programming-supplement.html)):
       - "Variables and Namespaces"
@@ -108,49 +115,51 @@ Recommended sequence:
       - "Subsetting"
       - "Controlling Program Flow"
     * *(optional)* Quiz Description video ([link](https://drive.google.com/file/d/1mA5umVuGeezZIVapP9t2ZMCMKdsDMzic/view?usp=sharing))
-8. **(due January 24, 2026)** Complete `Quiz 1`
-9. Watch solution videos:
+9. **(due January 24, 2026)** Complete `Quiz 1`
+10. Watch solution videos:
     * Quiz 1 ([link](https://drive.google.com/file/d/1Yz0eF37P7BmW6C1t1-QFFeOwt_MyWogg/view?usp=drive_link))
-10. Review Week 2 lecture materials
+11. Review Week 2 lecture materials
     * lecture videos ([link](https://drive.google.com/drive/folders/1RzLcoA22EpZ2ijgemlyOiPQjXb6Dgnqt))
       - "Functions"
       - "Using External Packages"
       - "Debugging"
       - "Working with Files"
-    * *(optional)* Programming Assignment 1 description video ([link](https://drive.google.com/file/d/1lTCFRY9lpxvz-rPih8nf33TQiWaV2sum/view?usp=drive_link))
-11. **(due January 31, 2026)** Complete `Quiz 2`
-12. **(due January 31, 2026)** Submit `Programming Assignment 1`
-13. Watch solution videos
+    * *(optional)* Programming Assignment 1 description video ([link](https://drive.google.com/file/d/16jiwXodqZi5X1S1mKnAdTkVP3zD80KbW/view?usp=drive_link))
+12. **(due January 31, 2026)** Complete `Quiz 2`
+13. **(due January 31, 2026)** Submit `Programming Assignment 1`
+14. Watch solution videos
     * Quiz 2 ([link](https://drive.google.com/file/d/1LvTJXAe9_zeA8ISH2D1iTJWQFjO5suLs/view?usp=drive_link))
-    * Programming Assignment 1 ([link](https://drive.google.com/file/d/196tA7oURjCh7-aEV3OLkmbo-0Cf1_BrV/view?usp=drive_link))
-14. Review Week 3 lecture materials
+    * Programming Assignment 1 ([link](https://drive.google.com/file/d/1G2hKqfHmE9paQLSZGVy4YEJCD9b5rRq8/view?usp=drive_link))
+15. Review Week 3 lecture materials
     * lecture videos ([link](https://drive.google.com/drive/folders/17q_QMf5TTT_gMYGDhkn5V8yY_dpjHUeO))
     * Programming Supplement topics ([link](https://jameslamb.github.io/intro-to-r/code/programming-supplement.html)):
       - "Missing Values"
       - "Plotting"
       - "Manipulating Data Frames"
-    * *(optional)* Programming Assignment 2 description video ([link](https://drive.google.com/file/d/1o-KPSFapjP85TooNywc6HdPNv7csaFRE/view?usp=drive_link))
-15. Review Final Project materials
+    * *(optional)* Programming Assignment 2 description video ([link](https://drive.google.com/file/d/1_T-nmixLZzBwvMv3_hS2JdzUtsWD1B2k/view?usp=drive_link))
+16. Review Final Project materials
     * videos ([link](https://drive.google.com/drive/folders/1zP8VsIt9vpvD5LvLn4aUk5CtT9uJ-vmU))
     * rubrics ([link](https://jameslamb.github.io/intro-to-r/assignments/final_project.html))
     * "Practices to Avoid in R Programming" ([link](https://jameslamb.github.io/intro-to-r/assignments/bad-practices.html))
-16. **(due February 7, 2026)** Submit `Programming Assignment 2`
-17. **(due February 7, 2026)** Submit `Final Project Proposal`
-18. Watch solution videos
-    * Programming Assignment 2 ([link](https://drive.google.com/file/d/1BjkwPfre3iRSeY6HjzMWPQy8VKh7qFl1/view?usp=drive_link))
-19. Review Week 4 lecture materials
+17. **(due February 7, 2026)** Submit `Programming Assignment 2`
+18. **(due February 7, 2026)** Submit `Final Project Proposal`
+19. Watch solution videos
+    * Programming Assignment 2 pt.1 ([link](https://drive.google.com/file/d/15R8ljhqBiOcIl92ombhjDyhXBLzTvenK/view?usp=drive_link))
+    * Programming Assignment 2 pt.2 ([link](https://drive.google.com/file/d/1KLByaC232y6pDQEy7y1Naw7L-xusC8Cn/view?usp=sharing))
+    * Programming Assignment 2 pt.3 ([link](https://drive.google.com/file/d/1hO1JJoDgDRx6PToi2pxCDeYjffyjzvEy/view?usp=drive_link))
+20. Review Week 4 lecture materials
     * lecture videos ([link](https://drive.google.com/drive/folders/1pIHR3RXgqI9vbKm6u1HX_pYQDD9QOgyf?usp=drive_link))
     * Programming Supplement topics ([link](https://jameslamb.github.io/intro-to-r/code/programming-supplement.html)):
       - "Statistical Analysis"
       - "Text Processing"
       - "Software Principles"
       - "R Programming Best Practices"
-20. **(due February 14, 2026)** Submit `Final Project Script(s)`
-21. **(due February 14, 2026)** Submit `Final Project Written Report`
-22. **(due February 14, 2026)** Attend `Final Project Presentation` (video call)
+21. **(due February 14, 2026)** Submit `Final Project Script(s)`
+22. **(due February 14, 2026)** Submit `Final Project Written Report`
+23. **(due February 14, 2026)** Attend `Final Project Presentation` (video call)
   * present your final project code to your classmates
   * provide peer review feedback to your classmates
-23. **(due February 17, 2026)** *(optional)* complete `Extra Credit Assignment`
+24. **(due February 17, 2026)** *(optional)* complete `Extra Credit Assignment`
 
 \pagebreak
 
@@ -296,7 +305,7 @@ Example situations which are considered "excused" absences:
 * legal obligations (such as jury duty)
 * university-sanctioned activities and related travel
 * religious observance
-* other situations with written approval from the professor
+* other situations with written approval from the instructor
 
 For more, see https://bulletin.marquette.edu/policies/attendance/management/
 

--- a/syllabus.html
+++ b/syllabus.html
@@ -1539,6 +1539,12 @@ videos.</p>
 February 14, 9:00a-12:00P CT</strong>.</p>
 <p>Videos describing the solutions to quizzes and assignments will be
 made available after the deadlines for those items.</p>
+<div id="a-note-on-the-course-site" class="section level4">
+<h4>A note on the course site</h4>
+<p>The course site moved to <a href="https://jameslamb.github.io/intro-to-r" class="uri">https://jameslamb.github.io/intro-to-r</a> in late 2025.</p>
+<p>If you find any broken links anywhere, please inform the
+instructor.</p>
+</div>
 </div>
 <div id="required-hardware" class="section level3">
 <h3>Required Hardware</h3>
@@ -1566,11 +1572,12 @@ material at any pace and in any order you’d like.</p>
 <p>Recommended sequence:</p>
 <ol style="list-style-type: decimal">
 <li>Read this syllabus</li>
+<li>Watch the syllabus review video (<a href="https://drive.google.com/file/d/1DeNScj4ZgUrFV6R5BNTvKe-KVTfa8M3a/view?usp=drive_link">link</a>)</li>
 <li>Accept the calendar invitation for the final project presentation
 call.</li>
 <li>bookmark the course resources:
 <ul>
-<li>course site (<a href="https://jameslamb.github.io/intro-to-r/">link</a>)</li>
+<li>course site (<a href="https://jameslamb.github.io/intro-to-r/" class="uri">https://jameslamb.github.io/intro-to-r/</a>)</li>
 <li>programming supplement: (<a href="https://jameslamb.github.io/intro-to-r/code/programming-supplement.html">link</a>)</li>
 <li>office hours link: <a href="https://calendar.app.google/iKAUGVQjBhegyLHH8" class="uri">https://calendar.app.google/iKAUGVQjBhegyLHH8</a></li>
 </ul></li>
@@ -1611,7 +1618,7 @@ call.</li>
 <li>“Debugging”</li>
 <li>“Working with Files”</li>
 </ul></li>
-<li><em>(optional)</em> Programming Assignment 1 description video (<a href="https://drive.google.com/file/d/1lTCFRY9lpxvz-rPih8nf33TQiWaV2sum/view?usp=drive_link">link</a>)</li>
+<li><em>(optional)</em> Programming Assignment 1 description video (<a href="https://drive.google.com/file/d/16jiwXodqZi5X1S1mKnAdTkVP3zD80KbW/view?usp=drive_link">link</a>)</li>
 </ul></li>
 <li><strong>(due January 31, 2026)</strong> Complete
 <code>Quiz 2</code></li>
@@ -1620,7 +1627,7 @@ call.</li>
 <li>Watch solution videos
 <ul>
 <li>Quiz 2 (<a href="https://drive.google.com/file/d/1LvTJXAe9_zeA8ISH2D1iTJWQFjO5suLs/view?usp=drive_link">link</a>)</li>
-<li>Programming Assignment 1 (<a href="https://drive.google.com/file/d/196tA7oURjCh7-aEV3OLkmbo-0Cf1_BrV/view?usp=drive_link">link</a>)</li>
+<li>Programming Assignment 1 (<a href="https://drive.google.com/file/d/1G2hKqfHmE9paQLSZGVy4YEJCD9b5rRq8/view?usp=drive_link">link</a>)</li>
 </ul></li>
 <li>Review Week 3 lecture materials
 <ul>
@@ -1631,7 +1638,7 @@ call.</li>
 <li>“Plotting”</li>
 <li>“Manipulating Data Frames”</li>
 </ul></li>
-<li><em>(optional)</em> Programming Assignment 2 description video (<a href="https://drive.google.com/file/d/1o-KPSFapjP85TooNywc6HdPNv7csaFRE/view?usp=drive_link">link</a>)</li>
+<li><em>(optional)</em> Programming Assignment 2 description video (<a href="https://drive.google.com/file/d/1_T-nmixLZzBwvMv3_hS2JdzUtsWD1B2k/view?usp=drive_link">link</a>)</li>
 </ul></li>
 <li>Review Final Project materials
 <ul>
@@ -1645,7 +1652,9 @@ call.</li>
 <code>Final Project Proposal</code></li>
 <li>Watch solution videos
 <ul>
-<li>Programming Assignment 2 (<a href="https://drive.google.com/file/d/1BjkwPfre3iRSeY6HjzMWPQy8VKh7qFl1/view?usp=drive_link">link</a>)</li>
+<li>Programming Assignment 2 pt.1 (<a href="https://drive.google.com/file/d/15R8ljhqBiOcIl92ombhjDyhXBLzTvenK/view?usp=drive_link">link</a>)</li>
+<li>Programming Assignment 2 pt.2 (<a href="https://drive.google.com/file/d/1KLByaC232y6pDQEy7y1Naw7L-xusC8Cn/view?usp=sharing">link</a>)</li>
+<li>Programming Assignment 2 pt.3 (<a href="https://drive.google.com/file/d/1hO1JJoDgDRx6PToi2pxCDeYjffyjzvEy/view?usp=drive_link">link</a>)</li>
 </ul></li>
 <li>Review Week 4 lecture materials
 <ul>
@@ -1669,7 +1678,7 @@ call.</li>
 <li>present your final project code to your classmates</li>
 <li>provide peer review feedback to your classmates</li>
 </ul>
-<ol start="23" style="list-style-type: decimal">
+<ol start="24" style="list-style-type: decimal">
 <li><strong>(due February 17, 2026)</strong> <em>(optional)</em>
 complete <code>Extra Credit Assignment</code></li>
 </ol>
@@ -1940,7 +1949,7 @@ the final project.</p>
 <li>legal obligations (such as jury duty)</li>
 <li>university-sanctioned activities and related travel</li>
 <li>religious observance</li>
-<li>other situations with written approval from the professor</li>
+<li>other situations with written approval from the instructor</li>
 </ul>
 <p>For more, see <a href="https://bulletin.marquette.edu/policies/attendance/management/" class="uri">https://bulletin.marquette.edu/policies/attendance/management/</a></p>
 </div>


### PR DESCRIPTION
Closes #190

* updates links to lecture videos (I re-recorded a bunch of them today)
* fixes small formatting issues
* adds a note to the syllabus about links changing because of #190
* replace "professor" with "instructor" 😛 